### PR TITLE
ESLint周りの設定をし直す

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "bradlc.vscode-tailwindcss"
+        "bradlc.vscode-tailwindcss",
+        "dbaeumer.vscode-eslint"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,10 @@
   },
   "editor.quickSuggestions": {
     "strings": "on"
-  }
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.enable": true,
+  "eslint.format.enable": true,
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript", "plugin:tailwindcss/recommended"),
+  {
+    ignores: ["out/", ".next/", "node_modules/"],
+  }
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
- 拡張機能の推奨事項にeslintのプラグインを追加
- ファイル保存時ESLintの自動修正が行われるように設定
- `out/` や `.next/` などlintする必要がないディレクトリをESLintに無視させるよう設定